### PR TITLE
Linked entry titles with primary source, removed mirror links

### DIFF
--- a/index.html
+++ b/index.html
@@ -194,14 +194,13 @@
 		<!-- BEGIN LIBRARIES -->
 		<h2 id="libs">Libraries</h2>
 		<dl>
-			<dt id="macintalk">MacInTalk</dt>
+			<dt id="macintalk"><a href="http://www.unna.org/view.php?/apple/software/TextToSpeech">MacInTalk</a></dt>
 			<dd>
 				<p>Apple's official MacInTalk Text-to-Speech extension for Newton OS.</p>
 				<ul class="metadata">
 					<li>Author: <a href="http://www.apple.com/">Apple Computer, Inc.</a></li>
 					<li>Platform: Newton OS</li>
 					<li>License: Freeware</li>
-					<li>Mirror: <a href="http://www.unna.org/view.php?/apple/software/TextToSpeech">UNNA</a></li>
 				</ul>
 			</dd>
 			
@@ -259,7 +258,7 @@
 				</ul>
 			</dd>
 			
-			<dt>develop</dt>
+			<dt><a href="http://www.mactech.com/articles/develop/">develop</a></dt>
 			<dd>
 				<p>Apple’s quarterly technical journal published from 1990-1997, before being pulled into <a href="http://www.mactech.com/">MacTech magazine</a> as a regular column. The following issues contain Newton/NewtonScript-specific articles:</p>
 				<ul>
@@ -280,11 +279,10 @@
 				<ul class="metadata">
 					<li>Author: Various</li>
 					<li>Format: Magazine, HTML</li>
-					<li>Mirror: <a href="http://www.mactech.com/articles/develop/">MacTech</a></li>
 				</ul>
 			</dd>
 			
-			<dt>Dr. Dobb’s</dt>
+			<dt><a href="http://www.drdobbs.com/sitesearch?queryText=newtonscript">Dr. Dobb’s</a></dt>
 			<dd>
 				<p>Michael Swaine explored the Newton as a platform, NewtonScript as a programming language, and NTK as a development environment in 1994 &amp; 1995 for his “Programming Paradigms” column in <a href="http://www.drdobbs.com/">Dr. Dobb’s</a> magazine.</p>
 				<p><em>Note: Free registration required to view more than two articles.</em></p>
@@ -299,7 +297,6 @@
 				<ul class="metadata">
 					<li>Author: Michael Swaine</li>
 					<li>Format: Magazine, HTML</li>
-					<li>Mirror: <a href="http://www.drdobbs.com/sitesearch?queryText=newtonscript">Dr. Dobb’s</a></li>
 				</ul>
 			</dd>
 			
@@ -326,33 +323,33 @@
 				</ul>
 			</dd>
 			
-			<dt>How to Work with the Text-to-Speech Extension</dt>
+			<dt><a href="http://communicrossings.com/html/newton/newtscape/docs/a0000003.shtml">How to Work with the Text-to-Speech Extension</a></dt>
 			<dd>
 				<p>An example of developing with the <a href="http://www.unna.org/view.php?/apple/software/TextToSpeech">MacInTalk</a> Text-to-Speech extension.</p>
 				<ul class="metadata">
 					<li>Author: William Nelson, <a href="http://www.allaboutjake.com">Jake Bordens</a></li>
 					<li>Format: HTML</li>
-					<li>Mirror: <a href="http://communicrossings.com/html/newton/newtscape/docs/a0000003.shtml">Steve Weyer</a>, <a href="http://web.archive.org/web/19991007065839/http://resources.pdadash.com/newtund/NU/dev/a0000003.shtml">Internet Archive</a></li>
+					<li>Mirror: <a href="http://web.archive.org/web/19991007065839/http://resources.pdadash.com/newtund/NU/dev/a0000003.shtml">Internet Archive</a></li>
 				</ul>
 			</dd>
 			
-			<dt>More Newton Text to Speech</dt>
+			<dt><a href="http://communicrossings.com/html/newton/newtscape/docs/a0000004.shtml">More Newton Text to Speech</a></dt>
 			<dd>
 				<p>An explanation of the embedded commands available in the <a href="http://www.unna.org/view.php?/apple/software/TextToSpeech">MacInTalk</a> Text-to-Speech extension.</p>
 				<ul class="metadata">
 					<li>Author: Jim Bailey</li>
 					<li>Format: HTML</li>
-					<li>Mirror: <a href="http://communicrossings.com/html/newton/newtscape/docs/a0000004.shtml">Steve Weyer</a>, <a href="http://web.archive.org/web/19991007081258/http://resources.pdadash.com/newtund/NU/dev/a0000004.shtml">Internet Archive</a></li>
+					<li>Mirror: <a href="http://web.archive.org/web/19991007081258/http://resources.pdadash.com/newtund/NU/dev/a0000004.shtml">Internet Archive</a></li>
 				</ul>
 			</dd>
 			
-			<dt>Newton 2.x OS Q&amp;As</dt>
+			<dt><a href="http://www.unna.org/unna/apple/documentation/developer/QAs-2.x/html/qa.htm">Newton 2.x OS Q&amp;As</a></dt>
 			<dd>
 				<p>Additional clarification, documentation, and examples for Newton OS 2.x development, including a section devoted to NewtonScript (though much of the rest of the documentation is relevant to developing in NewtonScript anyway). Available as a single page containing all content or multiple pages by section.</p>
 				<ul class="metadata">
 					<li>Author: <a href="http://www.apple.com/">Apple Computer, Inc.</a></li>
 					<li>Format: HTML</li>
-					<li>Mirror: <a href="http://web.archive.org/web/19980529083047/http://www.newton-inc.com/dev/techinfo/qa/qa.htm">Internet Archive</a>, <a href="http://www.unna.org/unna/apple/documentation/developer/QAs-2.x/html/qa.htm">UNNA</a></li>
+					<li>Mirror: <a href="http://web.archive.org/web/19980529083047/http://www.newton-inc.com/dev/techinfo/qa/qa.htm">Internet Archive</a></li>
 				</ul>
 			</dd>
 			
@@ -365,13 +362,12 @@
 				</ul>
 			</dd>
 			
-			<dt>Newton Book Maker User’s Guide</dt>
+			<dt><a href="http://www.unna.org/unna/apple/development/Bookmaker/BookmakerUsersGuide.pdf">Newton Book Maker User’s Guide</a></dt>
 			<dd>
 				<p>Official documentation on creating digital books and application help for the Newton, including the use of NewtonScript to customize book interaction, display, and behavior.</p>
 				<ul class="metadata">
 					<li>Author: <a href="http://www.apple.com/">Apple Computer, Inc.</a></li>
 					<li>Format: PDF</li>
-					<li>Mirror: <a href="http://www.unna.org/unna/apple/development/Bookmaker/BookmakerUsersGuide.pdf">UNNA</a></li>
 				</ul>
 			</dd>
 
@@ -392,13 +388,12 @@
 				</ul>
 			</dd>
 			
-			<dt>Newton Formats</dt>
+			<dt><a href="http://www.unna.org/unna/apple/documentation/developer/NewtonFormats1.1.pdf">Newton Formats</a></dt>
 			<dd>
 				<p>Official documentation of Newton data formats and protocols.</p>
 				<ul class="metadata">
 					<li>Author: <a href="http://www.apple.com/">Apple Computer, Inc.</a></li>
 					<li>Format: PDF</li>
-					<li>Mirror: <a href="http://www.unna.org/unna/apple/documentation/developer/NewtonFormats1.1.pdf">UNNA</a></li>
 				</ul>
 			</dd>
 			
@@ -411,23 +406,22 @@
 				</ul>
 			</dd>	
 			
-			<dt>Newton OS 2.1 Engineering Documents</dt>
+			<dt><a href="http://www.unna.org/unna/apple/documentation/developer/EngineeringDocsOS2.1.pdf">Newton OS 2.1 Engineering Documents</a></dt>
 			<dd>
 				<p>Official documentation of changes and additions in Newton OS 2.1, including: NewtWorks, keyboard enhancements, grayscale imaging, graphics shapes, sound, dial-in networks, IrDA communications tool, and the eMate 300 multi-user environment.</p>
 				<ul class="metadata">
 					<li>Author: <a href="http://www.apple.com/">Apple Computer, Inc.</a></li>
 					<li>Format: PDF</li>
-					<li>Mirror: <a href="http://newted.org/download/manuals/NewtonOS21EngDoc.pdf">Newted</a>, <a href="http://www.unna.org/unna/apple/documentation/developer/EngineeringDocsOS2.1.pdf">UNNA</a></li>
+					<li>Mirror: <a href="http://newted.org/download/manuals/NewtonOS21EngDoc.pdf">Newted</a></li>
 				</ul>
 			</dd>
 			
-			<dt>Newton OS 2.1 Engineering Documents: Miscellaneous</dt>
+			<dt><a href="http://mirrors.unna.org/www.geocities.com/SiliconValley/Code/5100/newton/2_1misc.pdf">Newton OS 2.1 Engineering Documents: Miscellaneous</a></dt>
 			<dd>
 				<p>A preliminary draft version of <em>Chapter 11: Miscellaneous</em> that appears to have been intended to be added to the <em>Newton OS 2.1 Engineering Documents</em>, covering additions in Newton OS 2.1 that weren't, "[L]engthy enough to warrant their own chapters."</p>
 				<ul class="metadata">
 					<li>Author: <a href="http://www.apple.com/">Apple Computer, Inc.</a></li>
 					<li>Format: PDF</li>
-					<li>Mirror: <a href="http://mirrors.unna.org/www.geocities.com/SiliconValley/Code/5100/newton/2_1misc.pdf">UNNA</a></li>
 				</ul>
 			</dd>
 			
@@ -450,13 +444,13 @@
 				</ul>
 			</dd>
 			
-			<dt>Newton Programmer’s Guide: 2.1 OS Addendum</dt>
+			<dt><a href="http://www.unna.org/unna/apple/documentation/developer/ProgrammersGuideOS2.1Addenum.pdf">Newton Programmer’s Guide: 2.1 OS Addendum</a></dt>
 			<dd>
 				<p>Official documentation covering additions and changes in the Newton OS 2.1 application programming interfaces.</p>
 				<ul class="metadata">
 					<li>Author: <a href="http://www.apple.com/">Apple Computer, Inc.</a></li>
 					<li>Format: PDF</li>
-					<li>Mirror: <a href="http://newted.org/download/manuals/NewtonProgrammerGuide21Add.pdf">Newted</a>, <a href="http://www.unna.org/unna/apple/documentation/developer/ProgrammersGuideOS2.1Addenum.pdf">UNNA</a></li>
+					<li>Mirror: <a href="http://newted.org/download/manuals/NewtonProgrammerGuide21Add.pdf">Newted</a></li>
 				</ul>
 			</dd>
 			
@@ -470,17 +464,17 @@
 				</ul>
 			</dd>
 			
-			<dt>NewtonScript ByteCode</dt>
+			<dt><a href="http://www.unna.org/unna/development/documentation/NSBytecode/bytecode.html">NewtonScript ByteCode</a></dt>
 			<dd>
 				<p>Documentation of the NewtonScript bytecode as compiled through observation.</p>
 				<ul class="metadata">
 					<li>Author: Matthew Faupel</li>
 					<li>Format: HTML</li>
-					<li>Mirror: <a href="http://web.archive.org/web/20000304014401/http://archive.dstc.edu.au/AU/staff/david-arnold/newton/bytecode.html">Internet Archive</a>, <a href="http://www.unna.org/unna/development/documentation/NSBytecode/bytecode.html">UNNA</a></li>
+					<li>Mirror: <a href="http://web.archive.org/web/20000304014401/http://archive.dstc.edu.au/AU/staff/david-arnold/newton/bytecode.html">Internet Archive</a></li>
 				</ul>
 			</dd>
 			
-			<dt>￼NewtonScriptに見る: もうひとつのプロトタイプ指向</dt>
+			<dt><a href="http://ll.jus.or.jp/2008/slides/6/gnue.pdf">NewtonScriptに見る: もうひとつのプロトタイプ指向</a></dt>
 			<dd>
 				<p>An overview of the NewtonScript language presented at the 2008 <a href="http://ll.jus.or.jp/">Lightweight Language</a> conference in Toyko, Japan.</p>
 				<ul class="metadata">
@@ -506,11 +500,11 @@
 				<ul class="metadata">
 					<li>Author: Masahiro Saito
 					<li>Format: PDF</li>
-					<li>Mirror: <a href="http://web.archive.org/web/20070706152255/http://www.k-inet.com/~brown/ftp/newton/Documents/NewtonScript.pdf">Internet Archive</a>, <a href="http://www.newted.org/download/manuals/NewtonScriptProgramLang_J.pdf">Newted</a></li>
+					<li>Mirror: <a href="http://www.newted.org/download/manuals/NewtonScriptProgramLang_J.pdf">Newted</a></li>
 				</ul>
 			</dd>
 
-			<dt>Newton Technology Journal</dt>
+			<dt><a href="http://www.unna.org/view.php?/apple/documentation/developer/NewtonTechnologyJournal">Newton Technology Journal</a></dt>
 			<dd>
 				<p>Apple’s Newton-specific technical journal, published six times per year from 1995-1997. The content is 70% development and 30% marketing.</p>
 				<ul>
@@ -530,17 +524,15 @@
 				<ul class="metadata">
 					<li>Author: <a href="http://www.apple.com/">Apple Computer, Inc.</a>, Various</li>
 					<li>Format: PDF</li>
-					<li>Mirror: <a href="http://www.unna.org/view.php?/apple/documentation/developer/NewtonTechnologyJournal">UNNA</a></li>
 				</ul>
 			</dd>
 			
-			<dt>Newton Toolkit 1.6.x File Formats</dt>
+			<dt><a href="http://web.archive.org/web/20040809072819/http://www.geocities.com/SiliconValley/Code/5100/newton/ntkfrmat.pdf">Newton Toolkit 1.6.x File Formats</a></dt>
 			<dd>
 				<p>Official documentation of file formats used by <a href="#ntk">NTK</a> 1.6.x for Windows and Macintosh, specifically Project files, Layout files, and native code module files.</p>
 				<ul class="metadata">
 					<li>Author: <a href="http://www.apple.com/">Apple Computer, Inc.</a></li>
 					<li>Format: PDF</li>
-					<li>Mirror: <a href="http://web.archive.org/web/20040809072819/http://www.geocities.com/SiliconValley/Code/5100/newton/ntkfrmat.pdf">Internet Archive</a></li>
 				</ul>
 			</dd>
 			
@@ -553,13 +545,13 @@
 				</ul>
 			</dd>
 			
-			<dt>Newton User Interface Guidelines (for Newton 2.0)</dt>
+			<dt><a href="http://www.unna.org/unna/apple/documentation/developer/UserInterfaceGuidelinesOS2.0.pdf">Newton User Interface Guidelines</a> (for Newton 2.0)</dt>
 			<dd>
 				<p>Official documentation of Newton OS 2.0 user interface and how to optimize software for it, including the whys and hows.</p>
 				<ul class="metadata">
 					<li>Author: <a href="http://www.apple.com/">Apple Computer, Inc.</a></li>
 					<li>Format: Book, PDF</li>
-					<li>Mirror: <a href="http://www.newted.org/download/manuals/Newton20UIGuide.pdf">Newted</a>, <a href="http://www.unna.org/unna/apple/documentation/developer/UserInterfaceGuidelinesOS2.0.pdf">UNNA</a></li>
+					<li>Mirror: <a href="http://www.newted.org/download/manuals/Newton20UIGuide.pdf">Newted</a></li>
 				</ul>
 			</dd>
 			
@@ -573,7 +565,7 @@
 				</ul>
 			</dd>
 			
-			<dt>Programming for the Newton: Software Development with NewtonScript</dt>
+			<dt><a href="http://www.amazon.com/Programming-Newton-Software-Development-Newtonscript/dp/0124848001">Programming for the Newton: Software Development with NewtonScript</a></dt>
 			<dd>
 				<p></p>
 				<ul class="metadata">
@@ -582,23 +574,23 @@
 				</ul>
 			</dd>
 			
-			<dt>Programming for the Newton Using Macintosh</dt>
+			<dt><a href="http://web.archive.org/web/19980204043353/http://www.newton-inc.com/dev/techinfo/ProgNewtUsingMac/ProgNewt-1.html">Programming for the Newton Using Macintosh</a></dt>
 			<dd>
 				<p></p>
 				<ul class="metadata">
 					<li>Author: Julie McKeehan, Neil Rhodes</li>
 					<li>Format: Book, HTML</li>
-					<li>Mirror: <a href="http://web.archive.org/web/19980204043353/http://www.newton-inc.com/dev/techinfo/ProgNewtUsingMac/ProgNewt-1.html">Internet Archive</a>, <a href="http://www.unna.org/unna/development/documentation/ProgNewtUsingMac.zip">UNNA</a></li>
+					<li>Mirror: <a href="http://www.unna.org/unna/development/documentation/ProgNewtUsingMac.zip">UNNA</a></li>
 				</ul>
 			</dd>
 			
-			<dt>Programming for the Newton Using Windows</dt>
+			<dt><a href="http://web.archive.org/web/19980204043359/http://www.newton-inc.com/dev/techinfo/ProgNewtUsingWin/ProgNewtWin-1.html">Programming for the Newton Using Windows</a></dt>
 			<dd>
 				<p></p>
 				<ul class="metadata">
 					<li>Author: Julie McKeehan, Neil Rhodes</li>
 					<li>Format: Book</li>
-					<li>Mirror: <a href="http://web.archive.org/web/19980204043359/http://www.newton-inc.com/dev/techinfo/ProgNewtUsingWin/ProgNewtWin-1.html">Internet Archive</a>, <a href="http://www.unna.org/view.php?/development/documentation/ProgNewtUsingWin/">UNNA</a></li>
+					<li>Mirror: <a href="http://www.unna.org/view.php?/development/documentation/ProgNewtUsingWin/">UNNA</a></li>
 				</ul>
 			</dd>
 			
@@ -620,23 +612,22 @@
 				</ul>
 			</dd>
 
-			<dt>The NewtonScript Programming Language</dt>
+			<dt><a href="http://web.archive.org/web/20041010175535/www.cc.gatech.edu/~schoedl/projects/NewtonScript/">The NewtonScript Programming Language</a></dt>
 			<dd>
 				<p>An overview of NewtonScript language, illustrating the differences between object oriented programming paradigms and relating how some NewtonScript features have their own particular programatic flavor.</p>
 				<ul class="metadata">
 					<li>Author: Arno Schödl</li>
 					<li>Format: HTML</li>
-					<li>Mirror: <a href="http://web.archive.org/web/20041010175535/www.cc.gatech.edu/~schoedl/projects/NewtonScript/">Internet Archive</a></li>
 				</ul>
 			</dd>
 			
-			<dt>User Interface Guidelines for Newton OS 2.1 Keyboard Enhancements</dt>
+			<dt><a href="http://www.unna.org/unna/apple/documentation/developer/UserInterfaceKeyboardOS2.1.pdf">User Interface Guidelines for Newton OS 2.1 Keyboard Enhancements</a></dt>
 			<dd>
 				<p>A supplement to <em>Newton User Interface Guidelines</em> which specifically covers the keyboard enhancements in Newton OS 2.1.</p>
 				<ul class="metadata">
 					<li>Author: <a href="http://www.apple.com/">Apple Computer, Inc.</a></li>
 					<li>Format: PDF</li>
-					<li>Mirror: <a href="http://www.newted.org/download/manuals/NewtonKeyboardUIGuide.pdf">Newted</a>, <a href="http://www.unna.org/unna/apple/documentation/developer/UserInterfaceKeyboardOS2.1.pdf">UNNA</a></li>
+					<li>Mirror: <a href="http://www.newted.org/download/manuals/NewtonKeyboardUIGuide.pdf">Newted</a></li>
 				</ul>
 			</dd>
 			
@@ -654,13 +645,13 @@
 		<!-- BEGIN SAMPLE CODE -->
 		<h2 id="samples">Sample Code</h2>
 		<dl>
-			<dt>Newton 2.x OS Sample Code</dt>
+			<dt><a href="http://web.archive.org/web/19980204042859/http://www.newton-inc.com/dev/samples.htm#newtonde">Newton 2.x OS Sample Code</a></dt>
 			<dd>
 				<p>Official sample Mac OS &amp; Windows <a href="#ntk">NTK</a> projects for Newton OS 2.x.</p>
 				<ul class="metadata">
 					<li>Author: <a href="http://www.apple.com/">Apple Computer, Inc.</a></li>
 					<li>Platform: Mac OS, Windows</li>
-					<li>Mirror: <a href="http://web.archive.org/web/19980204042859/http://www.newton-inc.com/dev/samples.htm#newtonde">Internet Archive</a>, <a href="http://www.unna.org/view.php?/apple/development/Examples/SampleCodeMac">UNNA (Mac OS)</a>, <a href="http://www.unna.org/view.php?/apple/development/Examples/SampleCodeWin">UNNA (Windows)</a></li>
+					<li>Mirror: <a href="http://www.unna.org/view.php?/apple/development/Examples/SampleCodeMac">UNNA (Mac OS)</a>, <a href="http://www.unna.org/view.php?/apple/development/Examples/SampleCodeWin">UNNA (Windows)</a></li>
 				</ul>
 			</dd>
 		</dl>


### PR DESCRIPTION
As per the discussion in issue #5, I’ve gone through all of the entries and linked their titles to the most obvious (or primary) source. I have also removed the aforementioned links in the “mirror” metadata to eliminate any duplication. Let me know what you think.